### PR TITLE
Update connection to TypeSafe repo to HTTPS.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies._
 val buildResolvers = Seq(
     "Local Maven Repository"    at "file://"+Path.userHome.absolutePath+"/.m2/repository",
     "Maven repository"          at "http://download.java.net/maven/2/",
-    "Typesafe Repo"             at "http://repo.typesafe.com/typesafe/releases/",
+    "Typesafe Repo"             at "https://repo.typesafe.com/typesafe/releases/",
     "Sonatype Snapshots"        at "http://oss.sonatype.org/content/repositories/snapshots",
     "Sonatype Releases"         at "http://oss.sonatype.org/content/repositories/releases"
   )


### PR DESCRIPTION
Fix "Failed to connect to repo.typesafe.com" error when building Docker image by connecting to the Typesafe repository through HTTPS rather than HTTP.

When using HTTP, I got plenty of errors similar to this one:

```
#12 110.4 [error] 	Typesafe Repo: unable to get resource for ch/qos/logback#logback-parent;1.2.3: res=http://repo.typesafe.com/typesafe/releases/ch/qos/logback/logback-parent/1.2.3/logback-parent-1.2.3.jar: java.net.ConnectException: Failed to connect to repo.typesafe.com/3.227.151.163:80
```

Afterwards it worked as expected.